### PR TITLE
Add a breaking test with Node.js 4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+sudo: false
+node_js:
+- '0.10'
+- '0.12'
+- '4.0.0'
+script: make test

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ var json = JSON.stringify
 function run(js, path) {
   var m = new Module(path, module)
   m.paths = Module._nodeModulePaths(dirname(path))
+  m.id = path
   m.filename = path
   js = 'module.return=eval(' + json(js) + ')'
   m._compile(js, path)

--- a/index.js
+++ b/index.js
@@ -14,7 +14,6 @@ var json = JSON.stringify
 function run(js, path) {
   var m = new Module(path, module)
   m.paths = Module._nodeModulePaths(dirname(path))
-  console.log(m.paths);
   m.filename = path
   js = 'module.return=eval(' + json(js) + ')'
   m._compile(js, path)

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ var json = JSON.stringify
 function run(js, path) {
   var m = new Module(path, module)
   m.paths = Module._nodeModulePaths(dirname(path))
+  console.log(m.paths);
   m.filename = path
   js = 'module.return=eval(' + json(js) + ')'
   m._compile(js, path)

--- a/test/eval.test.js
+++ b/test/eval.test.js
@@ -22,6 +22,7 @@ it('should be able to run external requires', function (){
 it('should be able to run external requires with fake path', function (){
   var context = path.resolve(__dirname, './bar/foo.js');
   var m = run('var an = require(\'../fixtures/another\');module.exports = function (a) { return an(a + 1) };', context);
+  console.log(m.paths);
   var val = m.exports(3);
   assert(val == 8);
 });

--- a/test/eval.test.js
+++ b/test/eval.test.js
@@ -19,6 +19,13 @@ it('should be able to run external requires', function (){
   assert(val == 6);
 });
 
+it('should be able to run external requires with fake path', function (){
+  var context = path.resolve(__dirname, './bar/foo.js');
+  var m = run('var an = require(\'../fixtures/another\');module.exports = function (a) { return an(a + 1) };', context);
+  var val = m.exports(3);
+  assert(val == 8);
+});
+
 it('should provide access to the return value', function(){
   var m = run('1;2;3');
   assert(m.return == 3);

--- a/test/eval.test.js
+++ b/test/eval.test.js
@@ -1,6 +1,6 @@
-
-var assert = require('better-assert')
+var assert = require('better-assert');
 var run = require('..');
+var path = require('path');
 
 it('should have a useful `require`', function(){
   var m = run('module.exports = require("..")', __filename);
@@ -10,6 +10,13 @@ it('should have a useful `require`', function(){
 it('should run in this context', function(){
   var m = run('module.exports = function(){}', __filename);
   assert(m.exports instanceof Function);
+});
+
+it('should be able to run external requires', function (){
+  var context = path.resolve(__dirname, '../foo.js');
+  var m = run('var an = require(\'./test/fixtures/another\');module.exports = function (a) { return an(a + 1) };', context);
+  var val = m.exports(2);
+  assert(val == 6);
 });
 
 it('should provide access to the return value', function(){

--- a/test/eval.test.js
+++ b/test/eval.test.js
@@ -1,18 +1,18 @@
 
 var assert = require('better-assert')
-var run = require('..')
+var run = require('..');
 
 it('should have a useful `require`', function(){
-  var m = run('module.exports = require("..")', __filename)
-  assert(m.exports == run)
-})
+  var m = run('module.exports = require("..")', __filename);
+  assert(m.exports == run);
+});
 
 it('should run in this context', function(){
-  var m = run('module.exports = function(){}', __filename)
-  assert(m.exports instanceof Function)
-})
+  var m = run('module.exports = function(){}', __filename);
+  assert(m.exports instanceof Function);
+});
 
 it('should provide access to the return value', function(){
-  var m = run('1;2;3')
-  assert(m.return == 3)
-})
+  var m = run('1;2;3');
+  assert(m.return == 3);
+});

--- a/test/eval.test.js
+++ b/test/eval.test.js
@@ -22,7 +22,6 @@ it('should be able to run external requires', function (){
 it('should be able to run external requires with fake path', function (){
   var context = path.resolve(__dirname, './bar/foo.js');
   var m = run('var an = require(\'../fixtures/another\');module.exports = function (a) { return an(a + 1) };', context);
-  console.log(m.paths);
   var val = m.exports(3);
   assert(val == 8);
 });

--- a/test/fixtures/another.js
+++ b/test/fixtures/another.js
@@ -1,0 +1,3 @@
+module.exports = function (input) {
+  return input * 2;
+};


### PR DESCRIPTION
This PR adds two things:
- Travis CI configuration for test automation with various stable Node.js versions
- A failing test to show that `../` require paths don't get handled correctly on Node 4.x
